### PR TITLE
update openai-whisper and add Pillow missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-openai-whisper==20240930
+openai-whisper==20250625
 srt==3.5.3
-imageio-ffmpeg==0.4.9
+imageio-ffmpeg==0.6.0
 numpy>=1.24.3
-torch>=2.0.0 
+torch>=2.0.0
+pillow==12.0.0


### PR DESCRIPTION
I tried to install Subtitle-Generator-AI on Windows 11, but I got `KeyError: '__version__'` when installing `openai-whisper==20240930`.

To troubleshoot the issue, I tried again `pip install` but removed the version specification from `openai-whisper`, `srt` and `imageio-ffmpeg`. The `pip install` worked with these modifications.

However, when executed `python main.py`, the following error appeared:
```
Traceback (most recent call last):
  File "C:\Users\cdal\Documents\GitHub\Subtitle-Generator-AI\main.py", line 18, in <module>
    from subtitle_generator.gui import SubtitleGeneratorApp
  File "C:\Users\cdal\Documents\GitHub\Subtitle-Generator-AI\subtitle_generator\gui.py", line 11, in <module>
    from PIL import Image, ImageTk
ModuleNotFoundError: No module named 'PIL'
```

To resolve this, I added `pillow` in the `requirements.txt`. By installing the `pillow`, the GUI worked and several subtitle generations were successful.

Finally, I executed `pip freeze` on my local environment, and provided in this commit the versions of the working environment.